### PR TITLE
fix for https://github.com/babel/babel/pull/3195

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,7 @@ export default function JsxDisplayIf({types: t}) {
                 let newJsxElement = t.JSXElement(
                     newJsxOpeningElement,
                     node.closingElement,
-                    node.children.map(child => {
-                        return child.type === 'JSXText'
-                            ? t.stringLiteral(child.value)
-                            : child;
-                    }).filter(child => {
-                        return child.type !== 'StringLiteral' ||
-                            /[^\s]/.test(child.value);
-                    })
+                    node.children
                 );
                 let conditionalExpression = t.conditionalExpression(
                     ifAttribute.value.expression,

--- a/package.json
+++ b/package.json
@@ -25,13 +25,12 @@
   "license": "MIT",
   "repository": "craftsy/babel-plugin-jsx-display-if",
   "dependencies": {
-    "babel-core": "^6.3.17"
+    "babel-core": "^6.4.0"
   },
   "devDependencies": {
-    "babel": "^6.4.0",
     "babel-cli": "^6.4.0",
     "babel-plugin-transform-react-jsx": "^6.4.0",
-    "babel-preset-es2015": "^6.4.0",
+    "babel-preset-es2015": "^6.3.13",
     "chai": "^3.3.0",
     "js-beautify": "^1.5.10",
     "mocha": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "babel-core": "^6.3.17"
   },
   "devDependencies": {
-    "babel": "^6.3.13",
-    "babel-cli": "^6.3.17",
-    "babel-plugin-transform-react-jsx": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
+    "babel": "^6.4.0",
+    "babel-cli": "^6.4.0",
+    "babel-plugin-transform-react-jsx": "^6.4.0",
+    "babel-preset-es2015": "^6.4.0",
     "chai": "^3.3.0",
     "js-beautify": "^1.5.10",
     "mocha": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "babel plugin to add conditional display ala ng-if to jsx",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --reporter spec",
-    "build": "babel -d dist index.js"
+    "test": "node_modules/.bin/mocha --compilers js:babel-core/register --reporter spec",
+    "build": "node_modules/.bin/babel -d dist index.js"
   },
   "keywords": [
     "babel",

--- a/test/test.js
+++ b/test/test.js
@@ -92,9 +92,15 @@ describe('jsx-if', function() {
         const compiled = transform(code, transformOptions).code;
         expect(b(compiled)).to.equal(b(expected));
     });
-    it('ignores whitespace only children', function () {
+    it('preserves whitespace only children', function () {
         const code = '<span display-if={boo}>          </span>';
-        const expected = '"use strict";\n\nboo ? j("span", null) : null;';
+        const expected = `"use strict";
+
+            boo ? j(
+                "span",
+                null,
+                "          "
+            ) : null;`;
         const compiled = transform(code, transformOptions).code;
         expect(b(compiled)).to.equal(b(expected));
     });


### PR DESCRIPTION
- Breaking change in babel removes validation for StringLiteral
  and instead validates for JSXText
- Bonus: removes some hacky workaround code
