### PR TITLE
move babel-core to devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 coverage
 .idea
+package-lock.json

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,8 +13,8 @@ function JsxDisplayIf(_ref) {
                 var node = path.node;
 
                 var ifAttributes = node.openingElement.attributes.filter(function (_ref2) {
-                    var type = _ref2.type;
-                    var name = _ref2.name;
+                    var type = _ref2.type,
+                        name = _ref2.name;
                     return type === 'JSXAttribute' && name.name === 'display-if';
                 });
                 if (!ifAttributes.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-jsx-display-if",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "babel plugin to add conditional display ala ng-if to jsx",
   "main": "dist/index.js",
   "scripts": {
@@ -24,11 +24,9 @@
   ],
   "license": "MIT",
   "repository": "craftsy/babel-plugin-jsx-display-if",
-  "dependencies": {
-    "babel-core": "^6.4.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.4.0",
+    "babel-core": "^6.4.0",
     "babel-plugin-transform-react-jsx": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.3.0",


### PR DESCRIPTION
our security scans found that there is a vulnerability found on this package since this is using an old version of babel-core, which uses an old version of the json5 package (0.5.1)

```
├─┬ babel-plugin-jsx-display-if@3.0.0
│ └─┬ babel-core@6.26.3
│   └── json5@0.5.1
```

we found that babel-core is not being used as a dependency so the fix is to move it to devDependencies